### PR TITLE
오른쪽 사이드바 레이아웃 완성

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import s from "./DashboardLayout.module.scss";
 import CalendarPanel from "@/features/calendar/components/CalendarPanel";
+import Sidebar from "../sidebar/Sidebar";
+import TotalSide from "../sidebar/TotalSide";
 
 export default function DashboardLayout() {
   return (
@@ -14,8 +16,9 @@ export default function DashboardLayout() {
         </main>
       </section>
       <section className={s.listArea}>
-        <div>우측리스트</div>
-        <div>총합</div>
+        <h3>Side</h3>
+        <Sidebar />
+        <TotalSide />
       </section>
     </section>
   );

--- a/src/components/sidebar/Sidebar.module.scss
+++ b/src/components/sidebar/Sidebar.module.scss
@@ -1,0 +1,59 @@
+.sidebar_box {
+    max-height: 75vh;
+    overflow-y: scroll;
+    padding: 0 0 10%;
+    .date_group {
+        margin: 13px 0;
+        padding: 5px 7px;
+        border-radius: 8px;
+        background-color: #f5f4f4;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+        .date_title {
+            margin:5px 0 3px;
+            font-size: 14px;
+            font-weight: 700;
+        }
+        .daily_box {
+            display: flex;
+            justify-content: start;
+            align-items: center;
+            column-gap: 1rem;
+            margin: 5px 0;
+            padding: 10px;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+            & > * {
+                font-size: 13px;
+            }
+
+            .type {
+                display: block;
+                width: 10px;
+                height: 10px;
+                border-radius: 50%;
+                text-indent: -9999px;
+
+                &.income {
+                    background-color: $income;
+                }
+                &.expense {
+                    background-color: $expense;
+                }
+            }
+            .sort {
+                font-weight: 600;
+            }
+            .price {
+                font-weight: 500;
+                &.income {
+                    color: $income;
+                }
+            
+                &.expense {
+                    color: $expense;
+                }
+            }
+        }
+    }
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,0 +1,47 @@
+import s from './Sidebar.module.scss';
+
+const mockData = [
+  { date: '2025-05-01', type: '지출', sort: '식품', price: 40000 },
+  { date: '2025-05-02', type: '지출', sort: '생활용품', price: 50000 },
+  { date: '2025-05-02', type: '지출', sort: '외식', price: 140000 },
+  { date: '2025-05-02', type: '지출', sort: '쇼핑', price: 42300 },
+  { date: '2025-05-03', type: '지출', sort: '주유', price: 40000 },
+  { date: '2025-05-04', type: '지출', sort: '영화', price: 40000 },
+  { date: '2025-05-05', type: '지출', sort: '관리비', price: 140000 },
+  { date: '2025-05-05', type: '지출', sort: '대출이자', price: 400000 },
+  { date: '2025-05-05', type: '수입', sort: '월급', price: 3000000 },
+  { date: '2025-05-14', type: '지출', sort: '관리비', price: 40000 },
+  { date: '2025-05-15', type: '지출', sort: '관리비', price: 30000 },
+  { date: '2025-05-23', type: '지출', sort: '관리비', price: 20000 },
+  { date: '2025-05-24', type: '지출', sort: '통신비', price: 33000 },
+  
+];
+
+export default function Sidebar() {
+    
+    const grouped = mockData.reduce((acc, item) => {
+        if (!acc[item.date]) acc[item.date] = [];
+        acc[item.date].push(item);
+        return acc;
+    }, {} as Record<string, typeof mockData>);
+    
+    return (
+        <div className={s.sidebar_box}>
+            {Object.entries(grouped).map(([date, items]) => (
+                <div key={date} className={s.date_group}>
+                    <h4 className={s.date_title}>{new Date(date).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })}</h4>
+                    {items.map((item, idx) => (
+                    <div key={idx} className={s.daily_box}>
+                        <p className={`${s.type} ${s[item.type === '지출' ? 'expense' : 'income']}`}>{item.type}</p>
+                        <p className={s.sort}>{item.sort}</p>
+                        <p className={`${s.price} ${s[item.type === '지출' ? 'expense' : 'income']}`}>
+                        {item.type === '지출' ? '- ' : '+ '}{item.price.toLocaleString()} 원
+                        </p>
+                    </div>
+                    ))}
+                </div>
+                ))}
+        </div>
+    )
+    
+}

--- a/src/components/sidebar/TotalSide.module.scss
+++ b/src/components/sidebar/TotalSide.module.scss
@@ -1,0 +1,89 @@
+.total_wrap {
+    > .total_title {
+        padding: 10px 0 5px;
+        font-size: 15px;
+        font-weight: 700;
+    }
+    .inner {
+        margin: 5px 0;
+        padding: 8px;
+        background-color: #f5f4f4;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+        .sub_box {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin: 5px 0;
+            padding: 8px 10px;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+            
+            .sub_title {
+                position: relative;
+                padding-left: 15px;
+                font-size: 13px;
+                font-weight: 500;
+
+                &:after {
+                    position: absolute;
+                    left: 0;
+                    top: 50%;
+                    display: block;
+                    width: 10px;
+                    height: 10px;
+                    border-radius: 50%;
+                    transform: translateY(-50%);
+                    content: '';
+                }
+            }
+            &.expense {
+                .sub_title {
+                    &::after {
+                        background-color: $expense;
+                    }
+                }
+                .sub_price {
+                    color: $expense;
+                }
+            }
+            &.income {
+                .sub_title {
+                    &::after {
+                        background-color: $income;
+                    }
+                }
+                .sub_price {
+                    color: $income;
+                }
+            }
+            .sub_price {
+                font-size: 13px;
+                font-weight: 500;
+            }
+        }
+
+        .total_box {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin: 15px 0 5px;
+            padding: 15px 10px;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+        
+            .total_title {
+                font-size: 14px;
+                font-weight: 700;
+            }
+        
+            .total_price {
+                font-size: 14px;
+                font-weight: 700;
+            }
+        }
+    }
+}

--- a/src/components/sidebar/TotalSide.tsx
+++ b/src/components/sidebar/TotalSide.tsx
@@ -1,0 +1,55 @@
+import s from './TotalSide.module.scss';
+
+const mockData = [
+  { date: '2025-05-01', type: '지출', sort: '식품', price: 40000 },
+  { date: '2025-05-02', type: '지출', sort: '생활용품', price: 50000 },
+  { date: '2025-05-02', type: '지출', sort: '외식', price: 140000 },
+  { date: '2025-05-02', type: '지출', sort: '쇼핑', price: 42300 },
+  { date: '2025-05-03', type: '지출', sort: '주유', price: 40000 },
+  { date: '2025-05-04', type: '지출', sort: '영화', price: 40000 },
+  { date: '2025-05-05', type: '지출', sort: '관리비', price: 140000 },
+  { date: '2025-05-05', type: '지출', sort: '대출이자', price: 400000 },
+  { date: '2025-05-05', type: '수입', sort: '월급', price: 3000000 },
+  { date: '2025-05-14', type: '지출', sort: '관리비', price: 40000 },
+  { date: '2025-05-15', type: '지출', sort: '관리비', price: 30000 },
+  { date: '2025-05-23', type: '지출', sort: '관리비', price: 20000 },
+  { date: '2025-05-24', type: '지출', sort: '통신비', price: 33000 },
+  
+];
+
+export default function TotalSide() {
+    const totalIncome = mockData
+        .filter((item) => item.type === '수입')
+        .reduce((acc, item) => acc + item.price, 0);
+    const totalExpense = mockData
+        .filter((item) => item.type === '지출')
+        .reduce((acc, item) => acc + item.price, 0);
+    const total = totalIncome - totalExpense;
+
+    return (
+        <div className={s.total_wrap}>
+            <h3 className={s.total_title}>Total</h3>
+            <div className={s.inner}>
+                <div className={`${s.sub_box} ${s.income}`}>
+                    <p className={s.sub_title}>총 수입</p>
+                    <p className={s.sub_price}>
+                        + {totalIncome.toLocaleString()} 원
+                    </p>
+                </div>
+                <div className={`${s.sub_box} ${s.expense}`}>
+                    <p className={s.sub_title}>총 지출</p>
+                    <p className={s.sub_price}>
+                        - {totalExpense.toLocaleString()} 원
+                    </p>
+                </div>
+                <div className={s.total_box}>
+                    <p className={s.total_title}>총 지출</p>
+                    <p className={s.total_price}>
+                        {total >= 0 ? '+ ' : '- '}
+                        {Math.abs(total).toLocaleString()} 원
+                    </p>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -32,6 +32,9 @@ $blue01: #0085ff;
 $blue02: #2eb4ff;
 $blue03: #e5f3ff;
 
+$income: #588bf3;
+$expense: #ee5353;
+
 .container {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
## 🛑 PR을 생성하실 때 `base 브랜치`를 **반드시 `develop`으로** 설정해주세요.

## 📝작업 내용

> 오른쪽 사이드바에서 상단에는 일 별로 지출/수입 및 카테고리와 금액이 표시되어 일 별로 구분이 지어짐
> 하단에는 월 별 총 수입과 지출, 그리고 총합이 나옴

### 📝작업 예정

- 달력 하단에 그래프를 추가해볼까 함

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e0ecff29-d773-4bd5-b5d9-fb67a4521ee9)

